### PR TITLE
feat(ca-certificates): install ca-certificates as a runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN set -x \
  && apk add --no-cache --virtual .nginx-rundeps $runDeps \
        bash \
        bash-completion \
+       ca-certificates \
        libintl \
 # Clean up build-time packages
  && apk del .build-deps \


### PR DESCRIPTION
adds about half a MB to the image

Which will enable [this](https://github.com/neighborhoods/kubernetes-charts/pull/1021/files#diff-b240e94ec74d5786ce24abecb13f70e878ccc06917a377fbafcaaa2ba3922761R30) to work properly.

We could remove the other CA's that we don't actually need that this change brings in but since the size difference is:
```
[I] ➜ docker images
REPOSITORY                        TAG       IMAGE ID       CREATED          SIZE
<none>                            <none>    ba7eba8cef64   8 minutes ago    26.9MB # whats on master
<none>                            <none>    bc9b34eada2a   23 minutes ago   27.4MB #With ca-certificates
```
🤷 