### PR TITLE
feat(openssl): update alpine and nginx to bind with openssl not libressl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.6
+FROM alpine:3.13
 
 LABEL maintainer="Neighborhoods.com <neighborhoods.engineering@neighborhoods.com>"
 
-ENV NGINX_VERSION=1.13.5
+ENV NGINX_VERSION=1.18.0
 
 RUN set -x \
  && mkdir -p \


### PR DESCRIPTION

a requirement for nginx-ldap-auths ca configurations

https://github.com/kvspb/nginx-auth-ldap\#ssl_check_cert

Image size went down about 2MB as well, which is nice since this gets used so much. Also gives us 20 months of [EOL](https://endoflife.date/alpine) on alpine and the version of nginx we were using isn't listed on the legacy version list, but was release Sept 5th, 2017. 🤷 

NEW openssl build:

```
docker-nginx-auth-ldap on  master on 🐳 v20.10.2 took 2s [I] ➜ docker run --rm  cdddd9a6289c  
nginx -V  nginx version: nginx/1.18.0
built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1) 
built with OpenSSL 1.1.1j  16 Feb 2021
TLS SNI support enabled
configure arguments: --prefix=/usr/share/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/tmp/src/nginx-auth-ldap-master
```

OLD Libre build:
```
docker-nginx-auth-ldap on  master on 🐳 v20.10.2 
[I] ➜ docker run --rm bc9b34eada2a  nginx -V
nginx version: nginx/1.13.5
built by gcc 6.3.0 (Alpine 6.3.0) 
built with LibreSSL 2.5.5
TLS SNI support enabled
configure arguments: --prefix=/usr/share/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-http_ssl_module --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --with-http_auth_request_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-threads --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_realip_module --with-stream_geoip_module=dynamic --with-http_slice_module --with-mail --with-mail_ssl_module --with-compat --with-file-aio --with-http_v2_module --add-module=/tmp/src/nginx-auth-ldap-master
```